### PR TITLE
Fix react router bugs

### DIFF
--- a/app/components/dev-tools.js
+++ b/app/components/dev-tools.js
@@ -1,4 +1,8 @@
 import React from 'react';
+/**
+ * Here, this was imported for the history.handlers on backbone.
+ * Gotta find what can replace it on React-Router
+ */
 import history from 'focus-core/history';
 import CoreStore from 'focus-core/store/CoreStore';
 import FocusDevTools from 'focus-devtools';

--- a/app/views/home/index.jsx
+++ b/app/views/home/index.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import history from 'focus-core/history';
-import {browserHistory} from 'react-router';
+import {navigate} from 'focus-core/history';
 import CoreStore from 'focus-core/store/CoreStore';
 
 // web components
@@ -18,8 +17,7 @@ export default React.createClass({
     mixins: [cartridgeBehaviour],
     /** @inheritDoc */
     _navigateAdvancedSearch() {
-        browserHistory.push('/search/advanced');
-        //history.navigate('#search/advanced', true);
+        navigate('/search/advanced');
     },
 
     /**

--- a/app/views/home/index.jsx
+++ b/app/views/home/index.jsx
@@ -16,9 +16,6 @@ export default React.createClass({
     displayName: 'HomeView',
     mixins: [cartridgeBehaviour],
     /** @inheritDoc */
-    _navigateAdvancedSearch() {
-        navigate('/search/advanced');
-    },
 
     /**
     * Related to the CartridgeBehaviour.
@@ -29,14 +26,14 @@ export default React.createClass({
         return {
             summary: {
                 component: SummaryPageSearch,
-                props: { onSearchCriteriaChangeByUser: this._navigateAdvancedSearch, service: searchService }
+                props: { onSearchCriteriaChangeByUser: () => {navigate('/search/advanced')}, service: searchService }
             },
             barLeft: {
                 component: DemoTitle
             },
             cartridge: {
                 component: CartridgePageSearch,
-                props: { onSearchCriteriaChangeByUser: this._navigateAdvancedSearch, service: searchService }
+                props: { onSearchCriteriaChangeByUser: () => {navigate('/search/advanced')}, service: searchService }
             },
             actions: {
                 primary: [],

--- a/app/views/menu/menu-left.jsx
+++ b/app/views/menu/menu-left.jsx
@@ -27,11 +27,6 @@ export default React.createClass({
         ];
     },
 
-    _onHomeClick() {
-        navigate('/');
-        window.scrollTo(0, 0);
-    },
-
     _onMenuItemClick() {
         this.setState({
             isQuickSearchModalOpen: false
@@ -68,7 +63,7 @@ export default React.createClass({
         const {isQuickSearchModalOpen} = this.state;
         return (
             <div>
-                <Menu onPopinClose={this._onQuickSearchModalToggle} items={items} handleBrandClick={this._onHomeClick} navigate={navigate} LinkComponent={Link}/>
+                <Menu onPopinClose={this._onQuickSearchModalToggle} items={items} handleBrandClick={() => {navigate('/');}} navigate={navigate} LinkComponent={Link}/>
                 {isQuickSearchModalOpen &&
                     <div data-demo='quick-search-area'>
                         <Modal open={true} type='from-menu'>

--- a/app/views/menu/menu-left.jsx
+++ b/app/views/menu/menu-left.jsx
@@ -1,7 +1,5 @@
 import React from 'react';
 
-// Browser  History make react-router works with the router
-import {browserHistory} from 'react-router';
 import {navigate} from 'focus-core/history';
 import Menu from 'focus-components/components/menu';
 import {component as Modal} from 'focus-components/application/popin';
@@ -21,9 +19,9 @@ export default React.createClass({
     },
     _getMenuItems() {
         return [
-            { icon:'home', route: '/' }, // route: 'home'
-            { icon:'search', onClick:() => { this._onQuickSearchModalToggle() }},
-            { icon:'build', route: '/admin/masterdata' }
+            { icon: 'home', route: '/' }, // route: 'home'
+            { icon: 'search', onClick: () => { this._onQuickSearchModalToggle() }},
+            { icon: 'build', route: '/admin/masterdata' }
         ];
     },
 

--- a/app/views/movie/components/movie-card.jsx
+++ b/app/views/movie/components/movie-card.jsx
@@ -67,7 +67,7 @@ export default React.createClass({
                 { showButtons &&
                     <div className='mdl-card__actions mdl-card--border'>
                         {onClickPreview && <Button shape={null} label='view.movie.action.preview' handleOnClick={() => onClickPreview(+code)} />}
-                        <Link to={`movies/${code}`}>
+                        <Link to={`/movies/${code}`}>
                             <Button shape={null} label='view.movie.action.consult.sheet' />
                         </Link>
                     </div>

--- a/app/views/movie/preview/index.jsx
+++ b/app/views/movie/preview/index.jsx
@@ -1,7 +1,7 @@
 //libraries
 import React, {PropTypes} from 'react';
 import {translate} from 'focus-core/translation';
-import history from 'focus-core/history';
+import {navigate} from 'focus-core/history';
 
 //web components
 import {component as Button} from 'focus-components/common/button/action';
@@ -42,7 +42,7 @@ export default React.createClass({
     },
 
     navigate() {
-        history.navigate(`movies/${this.props.id}`, true);
+        navigate(`/movies/${this.props.id}`);
         window.scrollTo(0, 0);
     },
 

--- a/app/views/movie/preview/index.jsx
+++ b/app/views/movie/preview/index.jsx
@@ -38,12 +38,7 @@ export default React.createClass({
     },
 
     onPopinClose() {
-        this.props.onPopinClose(this.navigate);
-    },
-
-    navigate() {
-        navigate(`/movies/${this.props.id}`);
-        window.scrollTo(0, 0);
+        this.props.onPopinClose(navigate(`/movies/${this.props.id}`));
     },
 
     /** @inheritDoc */

--- a/app/views/person/components/person-card.jsx
+++ b/app/views/person/components/person-card.jsx
@@ -1,6 +1,6 @@
 //libraries
 import React, {PropTypes} from 'react';
-import history from 'focus-core/history';
+import {navigate} from 'focus-core/history';
 import {Link} from 'react-router';
 
 //web components
@@ -8,6 +8,7 @@ import {component as Button} from 'focus-components/common/button/action';
 
 function PersonCard({onClickPreview, person}) {
     const {code, leadActor, linked, name, photoURL, role, existsInBdd} = person;
+    console.log('PERSON CODE', code);
     const showButtons = false !== existsInBdd;
     return (
         <div className='mdl-card mdl-shadow--4dp person-card' data-demo='material-card'>
@@ -30,9 +31,7 @@ function PersonCard({onClickPreview, person}) {
             { showButtons &&
               <div className='mdl-card__actions mdl-card--border'>
                   {onClickPreview && <Button shape={null} label='view.person.action.preview' handleOnClick={() => onClickPreview(+code)} />}
-                  <Link to={`persons/${code}`}>
-                      <Button shape={null} label='view.person.action.consult.sheet' />
-                  </Link>
+                      <Button shape={null} label='view.person.action.consult.sheet' onClick={() => {navigate(`/persons/${code}`)}} />
               </div>
             }
         </div>

--- a/app/views/person/detail/index.jsx
+++ b/app/views/person/detail/index.jsx
@@ -26,6 +26,10 @@ export default React.createClass({
     componentWillMount() {
         this._registerCartridge();
     },
+    
+    componentDidMount() {
+        window.scrollTo(0, 0);
+    },
 
     /**
     * Related to the CartridgeBehaviour.

--- a/app/views/person/preview/index.jsx
+++ b/app/views/person/preview/index.jsx
@@ -1,7 +1,7 @@
 //libraries
 import React, {PropTypes} from 'react';
 import {translate} from 'focus-core/translation';
-import history from 'focus-core/history';
+import {navigate} from 'focus-core/history';
 
 // web components
 import {component as Button} from 'focus-components/common/button/action';
@@ -38,12 +38,7 @@ export default React.createClass({
     },
 
     onPopinClose() {
-        this.props.onPopinClose(this.navigate);
-    },
-
-    navigate() {
-        history.navigate(`persons/${this.props.id}`, true);
-        window.scrollTo(0, 0);
+        this.props.onPopinClose(navigate(`/persons/${this.props.id}`));
     },
 
     /** @inheritDoc */

--- a/app/views/search/lines/line-click.js
+++ b/app/views/search/lines/line-click.js
@@ -1,5 +1,4 @@
-import history from 'focus-core/history';
-import {browserHistory} from 'react-router';
+import {navigate} from 'focus-core/history';
 
 //TODO : à revoir avec Pierre et Nicolas => comment je connais le type de ligne ???
 export default function onLineClick(data) {
@@ -14,6 +13,6 @@ export default function onLineClick(data) {
     if(isPerson) {
         url = `/persons/${code}`;
     }
-    browserHistory.push(url);
+    navigate(url);
     window.scrollTo(0, 0);
 }

--- a/app/views/search/quick/components/group.js
+++ b/app/views/search/quick/components/group.js
@@ -3,7 +3,6 @@ import React, {PropTypes, Component} from 'react';
 import Translation from 'focus-components/behaviours/translation';
 import formatter from 'focus-core/definition/formatter/number';
 import {navigate} from 'focus-core/history';
-import {browserHistory} from 'react-router';
 import {quickSearchStore} from 'focus-core/search/built-in-store';
 import dispatcher from 'focus-core/dispatcher';
 import {scopesConfig} from '../../../../config/scopes';

--- a/app/views/search/quick/components/group.js
+++ b/app/views/search/quick/components/group.js
@@ -1,8 +1,8 @@
 // libraires
 import React, {PropTypes, Component} from 'react';
 import Translation from 'focus-components/behaviours/translation';
-import formatter from  'focus-core/definition/formatter/number';
-import history from 'focus-core/history';
+import formatter from 'focus-core/definition/formatter/number';
+import {navigate} from 'focus-core/history';
 import {browserHistory} from 'react-router';
 import {quickSearchStore} from 'focus-core/search/built-in-store';
 import dispatcher from 'focus-core/dispatcher';
@@ -48,8 +48,7 @@ class QuickSearchGroup extends Component {
         if(showAllHandler){
             showAllHandler();
         }
-        browserHistory.push('/search/advanced');
-        // history.navigate('#search/advanced', true);
+        navigate('/search/advanced');
         window.scrollTo(0, 0);
     }
 


### PR DESCRIPTION
## FIX #164
## Navigate
- Now calling rightly and everywhere the focus core `navigate`
- Updating the code by removing functions which were calling navigate and using it directly (example on menu-left.jx OR on views/movie/preview/index.jsx
## URL Bug
- [x] Updating functions which where calling the `persons` url or the `movies` by adding a `/` to navigate correctly through the route
## Page To Top

The page, when clicking on a link, didn't go back the top of the page. 
By default I did a `window.scrollTo` on the `componentDidMount` to go to the top of the page on the first load. I'll see with you if you have a better way to do this with react-router @pierr @TomGallon 
